### PR TITLE
Wrap for loop args from zip operator with parens

### DIFF
--- a/t/01_texts.t
+++ b/t/01_texts.t
@@ -13,7 +13,7 @@ for @tests.sort -> $test {
  my @new_sentences = $text.sentences;
  my Str $diff="\n";
  my Str $expected_diff="\n";
- for @sentences Z @new_sentences -> $s1, $s2 {
+ for @sentences Z @new_sentences -> ($s1, $s2) {
      if ($s1 ne $s2) {
        $diff ~= "Expected: $s1\nGot: $s2\n"; 
      }


### PR DESCRIPTION
Parentheses are now required around args to a for loop when passing pairs
from a list.  This change makes the test suite pass again.
