### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Lingua/EN/Sentence.pm6
+++ b/lib/Lingua/EN/Sentence.pm6
@@ -1,4 +1,4 @@
-module Lingua::EN::Sentence:auth<LlamaRider>;
+unit module Lingua::EN::Sentence:auth<LlamaRider>;
 use v6;
 
 my Str $EOS="\0\0\0";


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.
