### PR TITLE
Use kebab-case with MONKEY-TYPING

### DIFF
--- a/lib/Lingua/EN/Sentence.pm6
+++ b/lib/Lingua/EN/Sentence.pm6
@@ -62,7 +62,7 @@ sub get_sentences(Str $text) is export {
 # augmenting the default Str class with a .sentences methods, 
 # for extra convenience. Sweet!
 #------------------------------------------------------------------------------
-use MONKEY_TYPING;
+use MONKEY-TYPING;
 augment class Str { method sentences { return get_sentences(self); } }
 
 #==============================================================================


### PR DESCRIPTION
The keyword `MONKEY-TYPING` is now in kebab-case; the underscore version of
the keyword is now deprecated and will be removed in the 2015.09 Rakudo
release.
