### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,12 +1,15 @@
 {
-    "perl" : "6.*",
-    "name" : "Lingua::EN::Sentence",
-    "version" : "0.1.2",
-    "description" : "Module for splitting text into sentences",
-    "author" : "Deyan Ginev",
-    "depends" : [ ],
-    "source-url" : "git://github.com/dginev/perl6-Lingua-EN-Sentence.git",
-    "provides": {
-      "Lingua::EN::Sentence": "lib/Lingua/EN/Sentence.pm6"
-    }
+  "name": "Lingua::EN::Sentence",
+  "source-url": "git://github.com/dginev/perl6-Lingua-EN-Sentence.git",
+  "perl": "6.*",
+  "author": "Deyan Ginev",
+  "depends": [
+    
+  ],
+  "license": "Artistic-2.0",
+  "provides": {
+    "Lingua::EN::Sentence": "lib/Lingua/EN/Sentence.pm6"
+  },
+  "version": "0.1.2",
+  "description": "Module for splitting text into sentences"
 }


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license